### PR TITLE
Fix version error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,5 +42,5 @@ custommachinery_version = 0.9.10
 jei_version = 11.6.0.1018
 kubejs_version = 1902.6.2-build.15
 ct_version = 10.1.50
-ars_version = 3.22.3.681
+ars_version = 3.22.3
 top_version = 1.19-6.2.0-6


### PR DESCRIPTION
The newest version of Ars Nouveau is 3.22.3, when use "ars_version = 3.22.3.681", the game will error:
[main/ERROR]: Missing or unsupported mandatory dependencies:
	Mod ID: 'ars_nouveau', Requested by: 'custommachineryars', Expected range: '[3.22.3.681,)', Actual version: '3.22.3'